### PR TITLE
bugfix/accurics_remediation_11060200050064073 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -5,16 +5,17 @@ resource "random_password" "password" {
 }
 
 resource "aws_db_instance" "database" {
-  allocated_storage       = 10
-  engine                  = "mysql"
-  engine_version          = "8.0"
-  instance_class          = "db.t2.micro"
-  identifier              = "${var.namespace}-db-instance"
-  name                    = "pets"
-  username                = "admin"
-  password                = random_password.password.result
-  db_subnet_group_name    = var.vpc.database_subnet_group
-  vpc_security_group_ids  = [var.sg.db]
-  skip_final_snapshot     = true
+  allocated_storage      = 10
+  engine                 = "mysql"
+  engine_version         = "8.0"
+  instance_class         = "db.t2.micro"
+  identifier             = "${var.namespace}-db-instance"
+  name                   = "pets"
+  username               = "admin"
+  password               = random_password.password.result
+  db_subnet_group_name   = var.vpc.database_subnet_group
+  vpc_security_group_ids = [var.sg.db]
+  skip_final_snapshot    = true
   #backup_retention_period = 50
+  backup_retention_period = 30
 }


### PR DESCRIPTION
Automated backups can be enabled using AWS Console or AWS CLI.
 In AWS Console - 
 1. Sign in to the AWS Console and go to the Amazon RDS console.
 2. Select Databases, and then choose the DB instance that you want to modify in the navigation pane.
 3. Select Modify.
 4. For Backup retention period, select the recommended 30 days value.
 5. Select Continue.
 6. Select Apply immediately.
 7. On the confirmation page, select Modify DB instance to save your changes and enable automated backups.
 Using AWS CLI - 
 Use the command : 'modify-db-instance' with the following parameters: 
   a.--db-instance-identifier 
   b. --backup-retention-period 
   c. --apply-immediately 
This will enable automated backups for AWS RDS instances.